### PR TITLE
Fixes required version of illuminate/encryption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/encryption": "~5.6"
+        "illuminate/encryption": "5.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
Laravel components doesn’t follow Semantic Versioning.

Good article about that: [https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5)