### PR TITLE
Pass $default to underlying function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,7 +10,7 @@ if (!function_exists('credentials')) {
         	$credentials = app(Credentials::class);
         	$credentials->load($filename);
 
-        	return $credentials->get($key);
+        	return $credentials->get($key, $default);
         } catch (ReflectionException $e) {
 			return Credentials::CONFIG_PREFIX.$key;
         }

--- a/tests/CredentialTest.php
+++ b/tests/CredentialTest.php
@@ -125,6 +125,22 @@ class CredentialTest extends TestCase
     }
 
     /** @test */
+    public function it_can_give_a_default_to_the_helper_function()
+    {
+        $this->app['config']->set('credentials.file', __DIR__ . '/temp/credentials.php.enc');
+
+        $data = [
+            'key' => 'my-secret-value'
+        ];
+
+        $credentials = app(Credentials::class);
+
+        $credentials->store($data, __DIR__ . '/temp/credentials.php.enc');
+
+        $this->assertSame('my-fallback-value', credentials('wrong-key', 'my-fallback-value'));
+    }
+
+    /** @test */
     public function it_replaces_credential_strings_in_the_configuration_files()
     {
         $this->app['config']->set('credentials.file', __DIR__ . '/temp/credentials.php.enc');


### PR DESCRIPTION
The parameter $default of the helper functions should be passed to the get()-method of the credentials object.