### PR TITLE
Add Support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/encryption": "5.6.*"
+        "illuminate/encryption": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
Laravel 5.7 uses a newer version of the illuminate/encryption package so modified the composer requirement to support anything greater than 5.6 to preserve backwards compatibility with Laravel 5.6 applications

Fixes #11 