### PR TITLE
Remove deprecated PHPUnit attributes and annotations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/CredentialTest.php
+++ b/tests/CredentialTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
 use BeyondCode\Credentials\Credentials;
+use Illuminate\Contracts\Encryption\DecryptException;
 use BeyondCode\Credentials\CredentialsServiceProvider;
 
 class CredentialTest extends TestCase
@@ -88,10 +89,11 @@ class CredentialTest extends TestCase
 
     /**
      * @test
-     * @expectedException Illuminate\Contracts\Encryption\DecryptException
      */
     public function it_can_not_decrypt_with_the_wrong_key()
     {
+        $this->expectException(DecryptException::class);
+
         $masterKey = Str::random(16);
 
         // create fake credentials


### PR DESCRIPTION
This PR:

- removes legacy attributes from phpunit.xml.dist
- removes deprecated `@expectedException` annotation (Such annotation will be removed in PHPUnit 9)
- uses `expectException()` assertion instead of `@expectedException` annotation