### PR TITLE
Update editor doc/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ With the built-in edit command, you can easily edit your existing credentials. T
 ```bash
 php artisan credentials:edit
 ```
+
+Optionally, you can change the used editor by adding the following to your .env file:
+
+```
+EDITOR=nano
+```
+
 ![Credentials Demo](https://beyondco.de/github/credentials.gif)
 
 ## Installation

--- a/config/credentials.php
+++ b/config/credentials.php
@@ -15,4 +15,6 @@ return [
 
     'cipher' => config('app.cipher'),
 
+    'editor' => env('EDITOR', 'vi')
+
 ];

--- a/src/EditCredentialsCommand.php
+++ b/src/EditCredentialsCommand.php
@@ -39,7 +39,7 @@ class EditCredentialsCommand extends Command
 
         fwrite($handle, json_encode($decrypted, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT));
 
-        $editor = env('EDITOR', 'vi');
+        $editor = config('credential.editor', 'vi');
 
         $process = new Process([$editor, $meta['uri']]);
 


### PR DESCRIPTION
Changing the editor wasn't listed.
Using the env variable wouldn't work in production as `env()` calls will return `null` once the application's configuration has been cached.

- Added a block to the README.MD file to list changing the used editor
- Added a new config variable to credentials.php
- Updated EditCredentialsCommand.php to use the config variable