### PR TITLE
Fixes required for Windows functionality

### DIFF
--- a/config/credentials.php
+++ b/config/credentials.php
@@ -15,6 +15,10 @@ return [
 
     'cipher' => config('app.cipher'),
 
-    'editor' => env('EDITOR', 'vi')
+    'editor' => env('EDITOR', 'vi'),
+
+    'editorParams' => env('EDITOR_PARAMS'),
+
+    'timeout' => env('EDITOR_TIMEOUT', 60)
 
 ];

--- a/src/EditCredentialsCommand.php
+++ b/src/EditCredentialsCommand.php
@@ -39,11 +39,19 @@ class EditCredentialsCommand extends Command
 
         fwrite($handle, json_encode($decrypted, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT));
 
-        $editor = config('credential.editor', 'vi');
+        $editor = config('credentials.editor', 'vi');
+        $editorParams = config('credentials.editorParams');
 
-        $process = new Process([$editor, $meta['uri']]);
+        $process = new Process([$editor, $editorParams, $meta['uri']],
+            null,
+            null,
+            null,
+            config('credentials.timeout'));
 
-        $process->setTty(true);
+        if (!(stripos(PHP_OS, 'WIN') === 0 || PHP_OS_FAMILY === "Windows"))
+        {
+            $process->setTty(true);
+        }
         $process->mustRun();
 
         $data = json_decode(file_get_contents($meta['uri']), JSON_OBJECT_AS_ARRAY);


### PR DESCRIPTION
Windows can't handle TTY, so this checks the OS before setting the flag. Allows the user to configure the timeout, because 60 seconds is annoying if you're setting a lot of variables. Also allows parameters to be passed into the editor call, as Visual Studio Code, for example, requires a -w flag to block the terminal until the user is done editing.

This resolves issue #37 and #15. It coincidentally duplicates the effort in #38, since it's impossible to test without that fix.
Kudos to @b0ric for the tty check conditions in #15.

Co-Authored-By: andrewkurzweil <26608741+andrewkurzweil@users.noreply.github.com>